### PR TITLE
修复Windows下资源无法加载的问题

### DIFF
--- a/serve/assest.go
+++ b/serve/assest.go
@@ -48,6 +48,7 @@ func (statics *AssestStruct) GetAssestFile(name string) (*AssestFile, error) {
 	if name != "" && name[0] != '/' {
 		name = "/" + name
 	}
+	name = strings.Replace(name,"\\","/",-1)
 	name = path.Clean(name)
 	if _assestDirect {
 		f, err := os.Open(_assestCwd + string(filepath.Separator) + name)


### PR DESCRIPTION
原因是window下资源的路径符合必须是\go才能识别并打开